### PR TITLE
Use OCITerminate() call to free memory properly

### DIFF
--- a/include/ocilib.h
+++ b/include/ocilib.h
@@ -1218,6 +1218,7 @@ typedef unsigned int big_uint;
 #define OCI_ENV_THREADED                    1
 #define OCI_ENV_CONTEXT                     2
 #define OCI_ENV_EVENTS                      4
+#define OCI_ENV_FORCE_TERM                  8
 
 /* sessions modes */
 

--- a/include/ocilib.hpp
+++ b/include/ocilib.hpp
@@ -696,7 +696,9 @@ public:
         /** Enable support for multi-threading */
         Threaded  = OCI_ENV_THREADED,
         /** Enable support for events related to subscriptions, HA and AQ notifications */
-        Events = OCI_ENV_EVENTS
+        Events = OCI_ENV_EVENTS,
+        /** call OCITerminate() function on Cleanup */
+        ForceTerminate = OCI_ENV_FORCE_TERM
     };
 
     /**

--- a/src/library.c
+++ b/src/library.c
@@ -190,6 +190,7 @@ static otext * FormatDefaultValues[OCI_FMT_COUNT] =
 /* OCI function pointers */
 
 OCIENVCREATE                 OCIEnvCreate                 = NULL;
+OCITERMINATE                 OCITerminate                 = NULL;
 OCISERVERATTACH              OCIServerAttach              = NULL;
 OCISERVERDETACH              OCIServerDetach              = NULL;
 OCIHANDLEALLOC               OCIHandleAlloc               = NULL;
@@ -820,7 +821,8 @@ boolean OCI_API OCI_Initialize
 
         LIB_SYMBOL(OCILib.lib_handle, "OCIEnvCreate", OCIEnvCreate,
                    OCIENVCREATE);
-
+        LIB_SYMBOL(OCILib.lib_handle, "OCITerminate", OCITerminate,
+                   OCITERMINATE);
         LIB_SYMBOL(OCILib.lib_handle, "OCIServerAttach", OCIServerAttach,
                    OCISERVERATTACH);
         LIB_SYMBOL(OCILib.lib_handle, "OCIServerDetach", OCIServerDetach,
@@ -1590,6 +1592,11 @@ boolean OCI_API OCI_Cleanup
     if (OCILib.env)
     {
         OCIHandleFree(OCILib.env, OCI_HTYPE_ENV);
+    }
+
+    if (OCILib.env_mode & OCI_ENV_FORCE_TERM)
+    {
+        OCITerminate(OCI_DEFAULT);
     }
 
 #ifdef OCI_IMPORT_RUNTIME

--- a/src/oci_api.h
+++ b/src/oci_api.h
@@ -79,6 +79,11 @@ typedef sword (*OCIENVCREATE)
     void   **usrmempp
 );
 
+typedef sword(*OCITERMINATE)
+(
+    ub4 mode
+);
+
 typedef sword (*OCIHANDLEALLOC)
 (
     const void  *parenth,

--- a/src/oci_import.h
+++ b/src/oci_import.h
@@ -91,6 +91,7 @@ extern "C" {
 /* symbol list */
 
 extern OCIENVCREATE                 OCIEnvCreate;
+extern OCITERMINATE                 OCITerminate;
 extern OCISERVERATTACH              OCIServerAttach;
 extern OCISERVERDETACH              OCIServerDetach;
 extern OCIHANDLEALLOC               OCIHandleAlloc;


### PR DESCRIPTION
Some memory leak detection tools report memory leaks without this call
